### PR TITLE
Refactoring and tiding up.

### DIFF
--- a/src/revsets.rs
+++ b/src/revsets.rs
@@ -1,15 +1,22 @@
 use std::path::PathBuf;
 
-use anyhow::{Error, Result};
-use jj_lib::config::{ConfigFile, ConfigLayer, ConfigLoadError, ConfigSource};
+use anyhow::{Error, Ok, Result};
+use jj_lib::config::{ConfigFile, ConfigLayer, ConfigSource, ConfigValue};
 
 #[derive(Debug)]
 pub struct Revsets {
     layer: ConfigLayer,
 }
 
+#[derive(Debug)]
+pub enum Alias {
+    Success,
+    Failures,
+    Pending,
+}
+
 impl Revsets {
-    pub fn new(source: ConfigSource, path: PathBuf) -> Result<Self, ConfigLoadError> {
+    pub fn new(source: ConfigSource, path: PathBuf) -> Result<Self, Error> {
         let res = Self {
             layer: ConfigLayer::load_from_file(source, path)?,
         };
@@ -17,56 +24,43 @@ impl Revsets {
         Ok(res)
     }
 
-    pub fn set_ci_success(&mut self, refs: Vec<String>) -> Result<(), Error> {
+    pub fn clean(&mut self) -> Result<Option<ConfigValue>, Error> {
+        // NOTE: Using `dummy` value here because the JJ template will fail if
+        // this value is an empty string.
+        self.layer
+            .set_value(r#"revset-aliases."ci_failures""#, "dummy")?;
+        self.layer
+            .set_value(r#"revset-aliases."ci_success""#, "dummy")?;
+        self.layer
+            .set_value(r#"revset-aliases."ci_pending""#, "dummy")?;
+        Ok(None)
+    }
+
+    pub fn update_alias(&mut self, refs: Vec<String>, alias: Alias) -> Result<(), Error> {
         let r: Vec<String> = refs.iter().map(|x| format!("present({x})")).collect();
         let value = r.join("|");
 
-        let _ = self
-            .layer
-            .set_value(r#"revset-aliases."ci_success""#, value)
-            .unwrap();
+        match alias {
+            Alias::Success => {
+                let _ = self
+                    .layer
+                    .set_value(r#"revset-aliases."ci_success""#, value)?;
+            }
+            Alias::Failures => {
+                let _ = self
+                    .layer
+                    .set_value(r#"revset-aliases."ci_failures""#, value)?;
+            }
+            Alias::Pending => {
+                let _ = self
+                    .layer
+                    .set_value(r#"revset-aliases."ci_pending""#, value)?;
+            }
+        }
 
         let _cfg = ConfigFile::from_layer(self.layer.clone().into()).unwrap();
         _cfg.save()?;
 
         Ok(())
-    }
-
-    pub fn set_ci_failures(&mut self, refs: Vec<String>) -> Result<(), Error> {
-        let r: Vec<String> = refs.iter().map(|x| format!("present({x})")).collect();
-        let value = r.join("|");
-
-        let _ = self
-            .layer
-            .set_value(r#"revset-aliases."ci_failures""#, value)
-            .unwrap();
-
-        let _cfg = ConfigFile::from_layer(self.layer.clone().into()).unwrap();
-        _cfg.save()?;
-
-        Ok(())
-    }
-
-    pub fn set_ci_pending(&mut self, refs: Vec<String>) -> Result<(), Error> {
-        let r: Vec<String> = refs.iter().map(|x| format!("present({x})")).collect();
-        let value = r.join("|");
-
-        let _ = self
-            .layer
-            .set_value(r#"revset-aliases."ci_pending""#, value)
-            .unwrap();
-
-        let _cfg = ConfigFile::from_layer(self.layer.clone().into()).unwrap();
-        _cfg.save()?;
-
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-mod test {
-    #[test]
-    fn test_set_ci_success() {
-        todo!();
     }
 }


### PR DESCRIPTION
- Simplify the revset aliases generation with enum instead of several methods.
- Always clean up the existing aliases before generating new ones, so that there will be no duplicates between aliases.
- Some refactoring to make things look better.