### PR TITLE
Bigger refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,6 +1709,7 @@ dependencies = [
  "clap",
  "jj-lib",
  "serde",
+ "serde_json",
  "tokio",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,6 @@ anyhow = "1.0.98"
 clap = { version = "4.5.40", features = ["derive"] }
 jj-lib = "0.30.0"
 serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
 tokio = { version = "1.45.1", features = ["io-std", "io-util", "macros", "process", "rt", "rt-multi-thread", "sync"] }
 toml = "0.8.23"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ coalesce(
   [...]
   if(self.contained_in("present(ci_pending)"), "⌛"),
   if(self.contained_in("present(ci_failures)"), "❌"),
+  if(self.contained_in("present(ci_canceled)"), "💀"),
   if(self.contained_in("present(ci_success)"), "✅"),
   [...]
 )
@@ -67,6 +68,7 @@ statement and a set of revset aliases. Each alias for each state:
 - ci_pending
 - ci_success
 - ci_failures
+- ci_canceled
 
 This way the same aliases will return different set of commits for different
 repository.

--- a/src/revsets.rs
+++ b/src/revsets.rs
@@ -13,6 +13,7 @@ pub enum Alias {
     Success,
     Failures,
     Pending,
+    Canceled,
 }
 
 impl Revsets {
@@ -33,6 +34,8 @@ impl Revsets {
             .set_value(r#"revset-aliases."ci_success""#, "dummy")?;
         self.layer
             .set_value(r#"revset-aliases."ci_pending""#, "dummy")?;
+        self.layer
+            .set_value(r#"revset-aliases."ci_canceled""#, "dummy")?;
         Ok(None)
     }
 
@@ -55,6 +58,11 @@ impl Revsets {
                 let _ = self
                     .layer
                     .set_value(r#"revset-aliases."ci_pending""#, value)?;
+            }
+            Alias::Canceled => {
+                let _ = self
+                    .layer
+                    .set_value(r#"revset-aliases."ci_canceled""#, value)?;
             }
         }
 


### PR DESCRIPTION
- Stop relying on jq command and use `serde_json` instead
- Introduce `ci_canceled` alias and track canceled pipelines
- Print less output